### PR TITLE
ValidationException::hasException should return a boolean and not an integer

### DIFF
--- a/sources/lib/Exception/ValidationException.php
+++ b/sources/lib/Exception/ValidationException.php
@@ -43,9 +43,9 @@ class ValidationException extends ParameterJuicerException
      *
      * Indicates if yes or no some exceptions have been set.
      */
-    public function hasExceptions(): int
+    public function hasExceptions(): bool
     {
-        return (bool) (count($this->exceptions) > 0);
+        return count($this->exceptions) > 0;
     }
 
     /**


### PR DESCRIPTION
ValidationException::hasException does not return a boolean but an integer, I think it's wrong because when I read a `has*` method I expect a boolean and because you cast the result in boolean inside the method (and it's not needed because it is already a boolean)