### PR TITLE
Use a callable as default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ validates the data according to the given definition.
                 ->setDefaultValue('pika', 9) // ← when not set
             ->addField('chu')
                 ->addCleaner('chu', function($v) { return trim($v); })
+                ->setDefaultValue('chu', function() { return 10; })
+                        // ↑ use a callable to have a lazy loaded default value
             ->addField('not mandatory', false)   // ← not mandatory
             ->setStrategy(Juicer::STRATEGY_IGNORE_EXTRA_VALUES)
             ;            // ↑ extra values are removed

--- a/sources/lib/ParameterJuicer.php
+++ b/sources/lib/ParameterJuicer.php
@@ -153,6 +153,12 @@ class ParameterJuicer implements ParameterJuicerInterface
      */
     public function setDefaultValue(string $name, $value): self
     {
+        if (false === is_callable($value)) {
+            $value = function () use ($value) {
+                return $value;
+            };
+        }
+
         $this
             ->checkFieldExists($name)
             ->default_values[$name] = $value
@@ -281,7 +287,7 @@ class ParameterJuicer implements ParameterJuicerInterface
     {
         foreach ($this->default_values as $field => $default_value) {
             if (!isset($values[$field]) && !array_key_exists($field, $values)) {
-                $values[$field] = $default_value;
+                $values[$field] = $default_value();
             }
         }
 

--- a/sources/lib/ParameterJuicer.php
+++ b/sources/lib/ParameterJuicer.php
@@ -287,7 +287,7 @@ class ParameterJuicer implements ParameterJuicerInterface
     {
         foreach ($this->default_values as $field => $default_value) {
             if (!isset($values[$field]) && !array_key_exists($field, $values)) {
-                $values[$field] = $default_value();
+                $values[$field] = call_user_func($default_value);
             }
         }
 

--- a/sources/tests/Unit/ParameterJuicer.php
+++ b/sources/tests/Unit/ParameterJuicer.php
@@ -223,7 +223,7 @@ class ParameterJuicer extends Atoum
     {
         $this
             ->assert('A mandatory field with a default value is OK when not provided.')
-            ->given($juicer = $this->newTestedInstance()->addField('pika')->setDefaultValue('pika', 'chu'))
+            ->given($juicer = $this->newTestedInstance()->addField('pika')->setDefaultValue('pika', function() { return 'chu'; }))
                 ->array($juicer->squash([]))
                     ->isEqualTo(['pika' => 'chu'])
             ->assert('Default value does not apply when field is set.')
@@ -233,6 +233,10 @@ class ParameterJuicer extends Atoum
             ->given($juicer->addCleaner('pika', function($v) { $v = trim($v); return strlen($v) === 0 ? null : $v; }))
                 ->array($juicer->squash(['pika' => '   ']))
                     ->isEqualTo(['pika' => null])
+            ->assert('Default value can not be a callable')
+            ->given($juicer->setDefaultValue('pika', 'chuu'))
+                ->array($juicer->squash([]))
+                    ->isEqualTo(['pika' => 'chuu'])
             ;
     }
 


### PR DESCRIPTION
This PR ref to #1 

Using a callable is not mandatory, it avoids BC break and write useless code because it can be boring to write an anonymous function just to return a standard scalar value.