### PR TITLE
Update atoum to version 3.0 and enable php 7.1 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: php
 php:
   - "7.0"
+  - "7.1"
 install: composer install --dev
 script:
-  - php vendor/atoum/atoum/bin/atoum --no-code-coverage -d sources/tests/Unit/
+  - php vendor/atoum/atoum/bin/atoum --no-code-coverage -d sources/tests/Unit/ -af vendor/autoload.php
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=7.0"
     },
     "require-dev": {
-        "atoum/atoum" : "dev-master"
+        "atoum/atoum": "~3.0.0"
     },
     "autoload": {
         "psr-4": {
@@ -29,4 +29,3 @@
     }
 
 }
-

--- a/composer.lock
+++ b/composer.lock
@@ -4,22 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e262ea663557e16d05ba532596b58143",
-    "content-hash": "a9927f2ebfc68b07289cf784c487b270",
+    "content-hash": "f1c71c576b0820a13b5939a56a82c601",
     "packages": [],
     "packages-dev": [
         {
             "name": "atoum/atoum",
-            "version": "dev-master",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/atoum/atoum.git",
-                "reference": "834e7c8fdaf23cc864a11dc1b6f2da71c5a038cc"
+                "reference": "decb381ef771ada37f8850774a9e9770a3da506f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/atoum/atoum/zipball/834e7c8fdaf23cc864a11dc1b6f2da71c5a038cc",
-                "reference": "834e7c8fdaf23cc864a11dc1b6f2da71c5a038cc",
+                "url": "https://api.github.com/repos/atoum/atoum/zipball/decb381ef771ada37f8850774a9e9770a3da506f",
+                "reference": "decb381ef771ada37f8850774a9e9770a3da506f",
                 "shasum": ""
             },
             "require": {
@@ -28,14 +27,18 @@
                 "ext-session": "*",
                 "ext-tokenizer": "*",
                 "ext-xml": "*",
-                "php": ">=5.3.3"
+                "php": "^5.6.0 || ^7.0.0"
             },
             "replace": {
                 "mageekguy/atoum": "*"
             },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~1.12"
+            },
             "suggest": {
                 "atoum/stubs": "Provides IDE support (like autocompletion) for atoum",
-                "ext-mbstring": "Provides support for UTF-8 strings"
+                "ext-mbstring": "Provides support for UTF-8 strings",
+                "ext-xdebug": "Provides code coverage report (>= 2.3)"
             },
             "bin": [
                 "bin/atoum"
@@ -43,7 +46,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
             },
             "autoload": {
@@ -86,14 +89,12 @@
                 "test",
                 "unit testing"
             ],
-            "time": "2017-02-11 13:23:46"
+            "time": "2017-02-22T13:05:37+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "atoum/atoum": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/sources/tests/Fixtures/PikaChuJuicer.php
+++ b/sources/tests/Fixtures/PikaChuJuicer.php
@@ -39,7 +39,7 @@ class PikaChuJuicer extends Juicer
     protected function mustNotBeEmptyString($value)
     {
         if (strlen($value) === 0) {
-            throw new ValidationException("Field 'pika' is an empty string.");
+            throw new ValidationException("cannot be empty.");
         }
     }
 
@@ -48,7 +48,7 @@ class PikaChuJuicer extends Juicer
         if ($value <= 0) {
             throw new ValidationException(
                 sprintf(
-                    "Field chu must be strictly positive (%f given).",
+                    "must be strictly positive (%f given).",
                     $value
                 )
             );

--- a/sources/tests/Fixtures/PikaChuJuicer.php
+++ b/sources/tests/Fixtures/PikaChuJuicer.php
@@ -9,6 +9,7 @@
  */
 namespace Chanmix51\ParameterJuicer\Tests\Fixtures;
 
+use Chanmix51\ParameterJuicer\Exception\ValidationException;
 use Chanmix51\ParameterJuicer\ParameterJuicer as Juicer;
 
 class PikaChuJuicer extends Juicer
@@ -38,12 +39,7 @@ class PikaChuJuicer extends Juicer
     protected function mustNotBeEmptyString($value)
     {
         if (strlen($value) === 0) {
-            throw new ValidationException(
-                sprintf(
-                    "Field '%s' is an empty string.",
-                    $name
-                )
-            );
+            throw new ValidationException("Field 'pika' is an empty string.");
         }
     }
 
@@ -52,8 +48,7 @@ class PikaChuJuicer extends Juicer
         if ($value <= 0) {
             throw new ValidationException(
                 sprintf(
-                    "Field '%s' must be strictly positive (%f given).",
-                    $name,
+                    "Field chu must be strictly positive (%f given).",
                     $value
                 )
             );

--- a/sources/tests/Fixtures/PokemonJuicer.php
+++ b/sources/tests/Fixtures/PokemonJuicer.php
@@ -9,6 +9,7 @@
  */
 namespace Chanmix51\ParameterJuicer\Tests\Fixtures;
 
+use Chanmix51\ParameterJuicer\Exception\ValidationException;
 use Chanmix51\ParameterJuicer\ParameterJuicer as Juicer;
 
 /**

--- a/sources/tests/Unit/ParameterJuicer.php
+++ b/sources/tests/Unit/ParameterJuicer.php
@@ -9,6 +9,8 @@
  */
 namespace Chanmix51\ParameterJuicer\Tests\Unit;
 
+use Chanmix51\ParameterJuicer\ParameterJuicer as Juicer;
+
 use Chanmix51\ParameterJuicer\Exception\ValidationException;
 use Chanmix51\ParameterJuicer\Exception\CleanerRemoveFieldException;
 use Chanmix51\ParameterJuicer\Tests\Fixtures\PokemonJuicer;
@@ -38,7 +40,7 @@ class ParameterJuicer extends Atoum
     public function testEmptyValidationWithAcceptStrategy()
     {
         $juicer = ($this->newTestedInstance())
-            ->setStrategy(2)
+            ->setStrategy(Juicer::STRATEGY_ACCEPT_EXTRA_VALUES)
             ;
         $this
             ->assert("Testing an empty validator & values and STRATEGY_ACCEPT_EXTRA_VALUES.")
@@ -60,7 +62,7 @@ class ParameterJuicer extends Atoum
     public function testEmptyValidationWithIgnoreStrategy()
     {
         $juicer = ($this->newTestedInstance())
-            ->setStrategy(0)
+            ->setStrategy(Juicer::STRATEGY_IGNORE_EXTRA_VALUES)
             ;
         $this
             ->assert("Testing an empty validator and STRATEGY_IGNORE_EXTRA_VALUES.")
@@ -84,7 +86,7 @@ class ParameterJuicer extends Atoum
     public function testEmptyValidationWithRefuseStrategy()
     {
         $juicer = ($this->newTestedInstance())
-            ->setStrategy(1)
+            ->setStrategy(Juicer::STRATEGY_REFUSE_EXTRA_VALUES)
             ;
         $this
             ->assert("Testing an empty validator & values and STRATEGY_REFUSE_EXTRA_VALUES.")
@@ -162,7 +164,7 @@ class ParameterJuicer extends Atoum
             ->addValidator('pika', $validate_range)
             ->addField('chu')
             ->addField('not mandatory', false)
-            ->setStrategy(1)
+            ->setStrategy(Juicer::STRATEGY_REFUSE_EXTRA_VALUES)
             ;
         $this
             ->assert("Checking validation with all mandatory data.")
@@ -289,10 +291,9 @@ class ParameterJuicer extends Atoum
     public function provideCompleteUseThatPass(): array
     {
         return [
-            [['pika' => ' Ah ah!'], 2, ['pika' => 'ah ah!']],
-            [['pika' => ' b  b   ', 'chu' => '3.141596'], 2, ['pika' => 'b b', 'chu' => 3.141596]],
-            [['pika' => 'cCc', 'extra' => 'oï'], 0, ['pika' => 'ccc', 'extra' => 'oï']],
-            [['pika' => 'cCc', 'extra' => 'oï'], 1, ['pika' => 'ccc']],
+            [['pika' => ' Ah ah!'], Juicer::STRATEGY_ACCEPT_EXTRA_VALUES, ['pika' => 'ah ah!']],
+            [['pika' => ' b  b   ', 'chu' => '3.141596'], Juicer::STRATEGY_ACCEPT_EXTRA_VALUES, ['pika' => 'b  b', 'chu' => 3.141596]],
+            [['pika' => 'cCc', 'extra' => 'oï'], Juicer::STRATEGY_IGNORE_EXTRA_VALUES, ['pika' => 'ccc']]
         ];
     }
 
@@ -302,7 +303,7 @@ class ParameterJuicer extends Atoum
      * More complex scenarios that pass.
      * @dataProvider provideCompleteUseThatPass
      */
-    public function completeUseThatPass(array $input, int $strategy, array $expected)
+    public function testCompleteUseThatPass(array $input, int $strategy, array $expected)
     {
         $this
             ->assert("Ignoring extra fields with cleaning & validation.")


### PR DESCRIPTION
This PR update atoum to version 3.0, enable php 7.1 on travis and fix some bugs in the test suite

I don't really know why but on php 7.1 I have to use the autoloader file option in atoum or it doesn't found fixtures classes